### PR TITLE
Improve Epub metadata parsing (read_text) and strip html tags from desc

### DIFF
--- a/src/epub_parser.rs
+++ b/src/epub_parser.rs
@@ -380,7 +380,10 @@ impl EpubParser {
         let decoded = unescape(input).unwrap_or(Cow::Borrowed(input));
 
         Builder::new()
-            .tags(vec!["b", "i", "em", "strong", "p", "br"].into_iter().collect::<HashSet<_>>())
+            .tags(vec![
+                "b", "i", "em", "strong", "p", "br",
+                "ul", "ol", "li", "blockquote", "a"
+            ].into_iter().collect::<HashSet<_>>())
             .clean(&decoded)
             .to_string()
     }


### PR DESCRIPTION
Description was missing for most of my books.
I updated the ```parse_opf_metadata()``` function to use ```read_text()``` and extract the fields correctly and I also added ```strip_html_tags()``` to clean the descriptions.

I tested it on my collection and now I have a description for every book.