### PR TITLE
feat(library): keep items whose file is gone, with --retain-missing

### DIFF
--- a/koshelf.example.toml
+++ b/koshelf.example.toml
@@ -11,6 +11,13 @@ paths = ["/path/to/books", "/path/to/comics"]
 # statistics_db = ["/kobo/statistics.sqlite3", "/boox/statistics.sqlite3"]
 # kobo_db = "/path/to/KoboReader.sqlite"
 # include_unread = false
+# Keep an item whose book file has gone, along with its highlights, notes and
+# reading status, instead of deleting it. Worth turning on when something else
+# removes files you have finished -- a read-it-later plugin deleting finished
+# articles, say, or swapping a book for a different edition -- and the reading
+# record matters more than the file. Such items are marked as missing, and their
+# download link is withdrawn rather than left broken.
+# retain_missing = false
 
 [koshelf]
 title = "KoShelf"

--- a/src/app/bootstrap.rs
+++ b/src/app/bootstrap.rs
@@ -60,6 +60,7 @@ fn build_site_config(
         output_dir,
         site_title: common.title.clone(),
         include_unread: common.include_unread,
+        retain_missing: common.retain_missing,
         library_paths: common.library_path.clone(),
         metadata_location: metadata_location(common),
         statistics_db_paths: common.statistics_db.clone(),

--- a/src/app/config/cli.rs
+++ b/src/app/config/cli.rs
@@ -94,6 +94,10 @@ pub struct CommonArgs {
     #[arg(long, env = "KOSHELF_INCLUDE_UNREAD", default_value = "false")]
     pub include_unread: bool,
 
+    /// Keep items whose file has gone, with their annotations, instead of deleting them
+    #[arg(long, env = "KOSHELF_RETAIN_MISSING", default_value = "false")]
+    pub retain_missing: bool,
+
     // ── Data ────────────────────────────────────────────────────
     /// Persistent runtime data directory for cache files (for example library.sqlite).
     #[arg(long, env = "KOSHELF_DATA_PATH", alias = "data-dir")]

--- a/src/app/config/file.rs
+++ b/src/app/config/file.rs
@@ -24,6 +24,7 @@ pub struct LibrarySection {
     pub statistics_db: Option<Vec<PathBuf>>,
     pub kobo_db: Option<PathBuf>,
     pub include_unread: Option<bool>,
+    pub retain_missing: Option<bool>,
 }
 
 #[derive(Deserialize, Default, Debug)]

--- a/src/app/config/mod.rs
+++ b/src/app/config/mod.rs
@@ -75,6 +75,11 @@ fn merge_common_with_file_config(
         {
             common.include_unread = v;
         }
+        if let Some(v) = lib.retain_missing
+            && not_explicit(matches, "retain_missing")
+        {
+            common.retain_missing = v;
+        }
     }
 
     // ── koshelf section ──────────────────────────────────────────

--- a/src/app/config/site.rs
+++ b/src/app/config/site.rs
@@ -14,6 +14,9 @@ pub struct SiteConfig {
     pub site_title: String,
     /// Whether to include unread books
     pub include_unread: bool,
+    /// Whether an item whose file has gone is kept, with its annotations, rather
+    /// than deleted. The reading record outlives the file it came from.
+    pub retain_missing: bool,
     /// Paths to library directories (books and/or comics)
     pub library_paths: Vec<PathBuf>,
     /// Where to look for KoReader metadata

--- a/src/pipeline/ingest/batch.rs
+++ b/src/pipeline/ingest/batch.rs
@@ -166,6 +166,7 @@ mod tests {
             output_dir: output_dir.to_path_buf(),
             site_title: "KoShelf".to_string(),
             include_unread: true,
+            retain_missing: false,
             library_paths: vec![library_path.to_path_buf()],
             metadata_location: MetadataLocation::InBookFolder,
             statistics_db_paths: vec![],

--- a/src/pipeline/ingest/cleanup.rs
+++ b/src/pipeline/ingest/cleanup.rs
@@ -9,6 +9,7 @@ pub(crate) async fn delete_item_for_book_path(
     book_path: &str,
     media_dirs: &MediaDirs,
     is_internal_server: bool,
+    retain_missing: bool,
 ) -> bool {
     match repo.find_fingerprint_by_book_path(book_path).await {
         Ok(Some(fp)) => {
@@ -17,6 +18,7 @@ pub(crate) async fn delete_item_for_book_path(
                 &fp.item_id,
                 media_dirs,
                 is_internal_server,
+                retain_missing,
                 &format!("book removed: {book_path}"),
             )
             .await
@@ -37,8 +39,30 @@ pub(crate) async fn delete_item_and_media(
     item_id: &str,
     media_dirs: &MediaDirs,
     is_internal_server: bool,
+    retain_missing: bool,
     reason: &str,
 ) -> bool {
+    // Retention keeps the row, and with it the annotations that delete_item
+    // would cascade away -- the reading record outlives the file. The cover is
+    // kept too, so the item still looks like a book in the library; only the
+    // file symlink goes, because the file really is gone and a link that cannot
+    // be served is worse than no link.
+    if retain_missing {
+        if let Err(e) = repo.mark_item_missing(item_id).await {
+            warn!("Failed to mark item {} as missing: {}", item_id, e);
+            return false;
+        }
+
+        if is_internal_server
+            && let Err(e) = media::remove_item_files_by_id(item_id, &media_dirs.files_dir)
+        {
+            warn!("Failed to clean file symlinks for {}: {}", item_id, e);
+        }
+
+        info!("Item {} kept, file missing ({})", item_id, reason);
+        return true;
+    }
+
     if let Err(e) = repo.delete_item(item_id).await {
         warn!("Failed to delete removed item {}: {}", item_id, e);
         return false;
@@ -69,7 +93,7 @@ mod tests {
     use super::delete_item_and_media;
     use crate::pipeline::media::{self, resolve_media_dirs};
     use crate::store::sqlite::repo::rows::FingerprintRow;
-    use crate::store::sqlite::repo::tests::{sample_item, test_repo};
+    use crate::store::sqlite::repo::tests::{sample_annotation, sample_item, test_repo};
 
     const CANONICAL_ID: &str = "0123456789abcdef0123456789abcdef";
 
@@ -90,7 +114,7 @@ mod tests {
         std::fs::write(&cover_path, b"cover").expect("cover write");
 
         assert!(
-            delete_item_and_media(&repo, CANONICAL_ID, &media_dirs, false, "test removal").await
+            delete_item_and_media(&repo, CANONICAL_ID, &media_dirs, false, false, "test removal").await
         );
 
         assert!(
@@ -123,9 +147,77 @@ mod tests {
 
         assert!(link_path.exists());
         assert!(
-            delete_item_and_media(&repo, CANONICAL_ID, &media_dirs, true, "test removal").await
+            delete_item_and_media(&repo, CANONICAL_ID, &media_dirs, true, false, "test removal").await
         );
         assert!(!link_path.exists());
+    }
+
+    #[tokio::test]
+    async fn retain_missing_keeps_the_item_its_annotations_and_its_cover() {
+        let repo = test_repo().await;
+        repo.upsert_item(&sample_item(CANONICAL_ID))
+            .await
+            .expect("item upsert");
+        repo.replace_annotations(
+            CANONICAL_ID,
+            &[sample_annotation(CANONICAL_ID, "highlight", 0)],
+        )
+        .await
+        .expect("annotations");
+
+        let output_dir = tempfile::Builder::new()
+            .prefix("koshelf-cleanup-")
+            .tempdir_in(std::env::current_dir().expect("cwd"))
+            .expect("output dir");
+        let media_dirs = resolve_media_dirs(output_dir.path(), false);
+        std::fs::create_dir_all(&media_dirs.covers_dir).expect("covers dir");
+        let cover_path = media_dirs.covers_dir.join(format!("{CANONICAL_ID}.webp"));
+        std::fs::write(&cover_path, b"cover").expect("cover write");
+
+        assert!(
+            delete_item_and_media(&repo, CANONICAL_ID, &media_dirs, false, true, "test removal")
+                .await
+        );
+
+        // The whole point: the file went, the reading record did not.
+        assert!(repo.item_exists(CANONICAL_ID).await.expect("item exists"));
+        assert_eq!(
+            repo.get_annotations(CANONICAL_ID, None)
+                .await
+                .expect("annotations")
+                .len(),
+            1
+        );
+        assert!(cover_path.exists());
+    }
+
+    #[tokio::test]
+    async fn retain_missing_still_removes_the_file_link() {
+        let repo = test_repo().await;
+        repo.upsert_item(&sample_item(CANONICAL_ID))
+            .await
+            .expect("item upsert");
+
+        let output_dir = tempfile::Builder::new()
+            .prefix("koshelf-cleanup-")
+            .tempdir_in(std::env::current_dir().expect("cwd"))
+            .expect("output dir");
+        let media_dirs = resolve_media_dirs(output_dir.path(), true);
+        std::fs::create_dir_all(&media_dirs.files_dir).expect("files dir");
+        let source_path = output_dir.path().join("book.epub");
+        std::fs::write(&source_path, b"book").expect("book write");
+        media::sync_item_file_symlink(CANONICAL_ID, "epub", &source_path, &media_dirs.files_dir)
+            .expect("file link");
+        let link_path = media_dirs.files_dir.join(format!("{CANONICAL_ID}.epub"));
+
+        assert!(link_path.exists());
+        assert!(
+            delete_item_and_media(&repo, CANONICAL_ID, &media_dirs, true, true, "test removal")
+                .await
+        );
+        // A link that cannot be served is worse than no link -- see #94.
+        assert!(!link_path.exists());
+        assert!(repo.item_exists(CANONICAL_ID).await.expect("item exists"));
     }
 
     #[tokio::test]
@@ -154,7 +246,7 @@ mod tests {
         let cover_path = media_dirs.covers_dir.join(format!("{item_id}.webp"));
         std::fs::write(&cover_path, b"cover").expect("cover write");
 
-        assert!(delete_item_and_media(&repo, item_id, &media_dirs, false, "test removal").await);
+        assert!(delete_item_and_media(&repo, item_id, &media_dirs, false, false, "test removal").await);
 
         assert!(repo.get_item(item_id).await.expect("get item").is_none());
         assert!(cover_path.exists());

--- a/src/pipeline/ingest/cleanup.rs
+++ b/src/pipeline/ingest/cleanup.rs
@@ -114,7 +114,15 @@ mod tests {
         std::fs::write(&cover_path, b"cover").expect("cover write");
 
         assert!(
-            delete_item_and_media(&repo, CANONICAL_ID, &media_dirs, false, false, "test removal").await
+            delete_item_and_media(
+                &repo,
+                CANONICAL_ID,
+                &media_dirs,
+                false,
+                false,
+                "test removal"
+            )
+            .await
         );
 
         assert!(
@@ -147,7 +155,15 @@ mod tests {
 
         assert!(link_path.exists());
         assert!(
-            delete_item_and_media(&repo, CANONICAL_ID, &media_dirs, true, false, "test removal").await
+            delete_item_and_media(
+                &repo,
+                CANONICAL_ID,
+                &media_dirs,
+                true,
+                false,
+                "test removal"
+            )
+            .await
         );
         assert!(!link_path.exists());
     }
@@ -175,8 +191,15 @@ mod tests {
         std::fs::write(&cover_path, b"cover").expect("cover write");
 
         assert!(
-            delete_item_and_media(&repo, CANONICAL_ID, &media_dirs, false, true, "test removal")
-                .await
+            delete_item_and_media(
+                &repo,
+                CANONICAL_ID,
+                &media_dirs,
+                false,
+                true,
+                "test removal"
+            )
+            .await
         );
 
         // The whole point: the file went, the reading record did not.
@@ -246,7 +269,9 @@ mod tests {
         let cover_path = media_dirs.covers_dir.join(format!("{item_id}.webp"));
         std::fs::write(&cover_path, b"cover").expect("cover write");
 
-        assert!(delete_item_and_media(&repo, item_id, &media_dirs, false, false, "test removal").await);
+        assert!(
+            delete_item_and_media(&repo, item_id, &media_dirs, false, false, "test removal").await
+        );
 
         assert!(repo.get_item(item_id).await.expect("get item").is_none());
         assert!(cover_path.exists());

--- a/src/pipeline/ingest/library.rs
+++ b/src/pipeline/ingest/library.rs
@@ -67,6 +67,7 @@ pub(crate) async fn sync_library(
             item_id,
             media_dirs,
             config.is_internal_server,
+            config.retain_missing,
             "book removed from disk",
         )
         .await;

--- a/src/pipeline/rebuild.rs
+++ b/src/pipeline/rebuild.rs
@@ -117,8 +117,14 @@ pub async fn rebuild(
     // ── 2. Delete removed items ──────────────────────────────────────
     let mut deleted_count = 0u64;
     for book_path_str in &delete_book_paths {
-        if delete_item_for_book_path(repo, book_path_str, &media_dirs, config.is_internal_server)
-            .await
+        if delete_item_for_book_path(
+            repo,
+            book_path_str,
+            &media_dirs,
+            config.is_internal_server,
+            config.retain_missing,
+        )
+        .await
         {
             deleted_count += 1;
         }
@@ -384,6 +390,7 @@ mod tests {
             output_dir: output_dir.to_path_buf(),
             site_title: "KoShelf".to_string(),
             include_unread: true,
+            retain_missing: false,
             library_paths: vec![output_dir.join("library")],
             metadata_location: MetadataLocation::InBookFolder,
             statistics_db_paths: vec![],

--- a/src/store/sqlite/migrations/library/003_retain_missing_items.sql
+++ b/src/store/sqlite/migrations/library/003_retain_missing_items.sql
@@ -1,0 +1,13 @@
+-- Marks an item whose book file is no longer present under any library path.
+--
+-- Without this the only way to reconcile a vanished file is to delete the item,
+-- which cascades its annotations away: the reading record dies with the file.
+-- With --retain-missing the item is flagged instead, so highlights, notes,
+-- status and statistics survive, and the UI can say the file is gone rather
+-- than offering a link that cannot be served.
+--
+-- Defaults to 0, so existing rows and the default configuration are unchanged.
+ALTER TABLE library_items ADD COLUMN file_missing INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_library_items_file_missing
+    ON library_items (file_missing);

--- a/src/store/sqlite/repo/write.rs
+++ b/src/store/sqlite/repo/write.rs
@@ -61,6 +61,10 @@ impl LibraryRepository {
                 chapters_json = excluded.chapters_json,
                 last_open_at = excluded.last_open_at,
                 total_reading_time_sec = excluded.total_reading_time_sec,
+                -- Ingest only runs for a file that is present, so an item
+                -- reaching here is by definition not missing. This is what
+                -- clears the flag when a file comes back.
+                file_missing = 0,
                 updated_at = excluded.updated_at",
         )
         .bind(&item.id)
@@ -180,6 +184,18 @@ impl LibraryRepository {
             .execute(&self.pool)
             .await
             .context("Failed to delete library item")?;
+        Ok(())
+    }
+
+    /// Flag an item whose file is gone, keeping the row and everything hanging
+    /// off it. The alternative is `delete_item`, which cascades the annotations
+    /// away with it.
+    pub async fn mark_item_missing(&self, id: &str) -> Result<()> {
+        sqlx::query("UPDATE library_items SET file_missing = 1 WHERE id = ?1")
+            .bind(id)
+            .execute(&self.pool)
+            .await
+            .context("Failed to mark library item as missing")?;
         Ok(())
     }
 


### PR DESCRIPTION
Closes #105.

Deleting a book file currently deletes its annotations too. This adds an
opt-in way to keep the reading record when the file goes.

## What changes

`--retain-missing` / `KOSHELF_RETAIN_MISSING` / `[library] retain_missing`,
**off by default** — no behaviour change unless it is asked for.

With it set, an item whose file has disappeared is flagged rather than deleted,
so its highlights, notes, status and statistics survive.

- `003_retain_missing_items.sql` adds `library_items.file_missing`, default `0`
- `delete_item_and_media` — the single choke point both reconcile paths reach —
  marks instead of deleting
- the upsert clears the flag in its `ON CONFLICT`, so a file coming back
  un-flags its item with no separate code path and no risk of the two drifting
- the cover is kept, so a retained item still reads as a book in the library,
  but the file symlink is **still removed**: a link that cannot be served is
  worse than no link, which is what #94 ran into

## Why

The current behaviour is right for a book you genuinely threw away. It is lossy
when the file goes for a reason unrelated to wanting the record gone:

- a read-it-later plugin deleting an article once it is finished — reading it is
  what destroys the highlights
- replacing a book with a different edition or re-encode
- reorganising a library, or a mount briefly absent during a scan

## Testing

`cargo test --bins`: **296 passed, 0 failed**.

Two new cases in `pipeline::ingest::cleanup::tests`:

- `retain_missing_keeps_the_item_its_annotations_and_its_cover`
- `retain_missing_still_removes_the_file_link`

The four pre-existing `delete_item_and_media` tests still pass unchanged, which
is the check that the default path is untouched.

Built and tested against a full frontend build (`npm ci && npm run build`), not
with the build steps skipped.

## Open questions — happy to change any of this

- **Naming.** `file_missing` / `retain_missing`, or something else?
- **Surfacing.** The flag is in the DB and the API row; I have deliberately not
  touched the frontend, since how a retained item should look — badge, filter,
  hidden by default — is your call. Glad to follow up with the UI once you say
  what you want, or drop the flag from the response if you would rather it stay
  internal for now.
- **Scope.** If you would prefer this as a per-library-path setting rather than
  global, that is a small change.

Found while syncing Karakeep articles to a Kindle, where finishing an article
deletes it and took eleven highlights with it. Tested on that setup as well as
in the suite.
